### PR TITLE
ADP-40 Reverse Proxy API Calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve",
+    "start": "ng serve --proxy-config proxy.conf.js",
     "build": "ng build --configuration production  --base-href ./ && cp CNAME dist/CNAME",
     "test": "ng test",
     "lint": "ng lint --force",

--- a/proxy.conf.js
+++ b/proxy.conf.js
@@ -1,0 +1,12 @@
+var PROXY_CONF = {
+  "/api": {
+    "target": process.env.API_URL || "http://localhost:8080",
+    "secure": true,
+    "pathRewrite": {
+    "^/api": ""
+  },
+    "changeOrigin": true
+  }
+}
+
+module.exports = PROXY_CONF

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,4 +1,5 @@
 export const environment = {
   production: true,
-  api_url: 'https://conduit.productionready.io/api'
+  // api_url: 'https://conduit.productionready.io/api'
+  api_url: '/api'
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -5,5 +5,6 @@
 
 export const environment = {
   production: false,
-  api_url: 'https://conduit.productionready.io/api'
+  // api_url: 'https://conduit.productionready.io/api'
+  api_url: '/api'
 };


### PR DESCRIPTION
Setup so that API calls go to the same host as the SPA Webapp. That host then reverse proxies those calls to some other API Server.